### PR TITLE
no debug in run-service.sh, new script with debugging

### DIFF
--- a/run-service-debug.sh
+++ b/run-service-debug.sh
@@ -17,5 +17,6 @@
 
 APPHOME=home
 
+MAVEN_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n" \
 LOGBACK_CONFIG="$APPHOME/cfg/logback-service.xml" \
 QUIET="-q" run.sh run-service $@

--- a/run-service-debug.sh
+++ b/run-service-debug.sh
@@ -16,7 +16,9 @@
 #
 
 APPHOME=home
+DEBUG_PORT=${1:-8000}
+shift
 
-MAVEN_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n" \
+MAVEN_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,address=$DEBUG_PORT,suspend=n" \
 LOGBACK_CONFIG="$APPHOME/cfg/logback-service.xml" \
-QUIET="-q" run.sh run-service $@
+run.sh run-service $@

--- a/run-service.sh
+++ b/run-service.sh
@@ -18,4 +18,4 @@
 APPHOME=home
 
 LOGBACK_CONFIG="$APPHOME/cfg/logback-service.xml" \
-QUIET="-q" run.sh run-service $@
+run.sh run-service $@


### PR DESCRIPTION
This PR is based on some frustrations while using the `run-service.sh` script in FREYA. I wasn't able to run two or more services this way, because it allocates port 8000 multiple times.
As a solution, I created a new script `run-service-debug.sh`, which is the same as the **old** `run-service.sh`. The **new** `run-service.sh` doesn't have the debug configuration added.

The naming of these scripts now is more consistent with the other naming policies in this repository, such as `run.sh` and `run-debug.sh`.

~~Finally, I also added the `QUIET` option by default, such that you don't see the _useless_ Maven header at the start of running the script.~~

@DANS-KNAW/easy @DANS-KNAW/narcis for review