### PR TITLE
Added shell script from Stackoverflow for creating random data. New s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ start-hsqldb.sh
 start-virtual-env.sh
 start-mkdocs.sh
 
+# Misc scripts
+rndtree.sh
+
 # Legacy projects
 run-reset-env.sh
 run.sh [ <arg>... ]

--- a/generate-random-files.py
+++ b/generate-random-files.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import random
+import shutil
+
+
+def create_random_file(filepath, minbytes, maxbytes):
+    with open(filepath, 'wb') as stream:
+        size = random.randint(minbytes, maxbytes)
+        stream.write(os.urandom(size))
+
+
+def create_random_name(minlen, maxlen, name_chars):
+    namelen = random.randint(minlen, maxlen)
+    random_name = ''
+    for _ in range(namelen):
+        random_index = random.randint(0, len(name_chars) - 1)
+        random_name += chr(name_chars[random_index])
+    return random_name
+
+
+def create_random_subdirs(dir, num, name_chars, minlen, maxlen, levels):
+    for i in range(num):
+        random_dir = '{}/{}'.format(dir, create_random_name(5, 10, name_chars))
+        os.mkdir(random_dir)
+        if levels > 0:
+            create_random_subdirs(random_dir, num, name_chars, minlen, maxlen, levels - 1)
+
+
+def create_random_files(dir, num, name_chars, minlen, maxlen, minbytes, maxbytes, level):
+    if level == 0:
+        for i in range(num):
+            random_file = '{}/{}.bin'.format(dir, create_random_name(minlen, maxlen, name_chars))
+            create_random_file(random_file, minbytes, maxbytes)
+    else:
+        for f in os.listdir(dir):
+            create_random_files('{}/{}'.format(dir, f), num, name_chars, minlen, maxlen, minbytes, maxbytes, level - 1)
+
+
+def main():
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument('-o', '--outdir',
+                        dest='outdir',
+                        help='the directory in which to create random files')
+    parser.add_argument('--num-files-per-dir',
+                        dest='files_per_dir',
+                        type=int,
+                        default=10,
+                        help='number of random files to create in each directory')
+    parser.add_argument('--min-bytes-per-file',
+                        dest='min_bytes_per_file',
+                        type=int,
+                        default=1,
+                        help='minimum bytes per file')
+    parser.add_argument('--max-bytes-per-file',
+                        dest='max_bytes_per_file',
+                        type=int,
+                        default=1024 * 1024,
+                        help='maximum bytes per file')
+    parser.add_argument('--num-subdirs',
+                        dest='num_subdirs',
+                        type=int,
+                        default=1,
+                        help='number of subdirectories at every level')
+    parser.add_argument('--num-levels',
+                        dest='num_levels',
+                        type=int,
+                        default=0,
+                        help='number of levels below outdir')
+    parser.add_argument('--min-dirname-length',
+                        dest='min_dirname_length',
+                        default=10,
+                        help='minimum length of directory names')
+    parser.add_argument('--max-dirname-length',
+                        dest='max_dirname_length',
+                        type=int,
+                        default=10,
+                        help='maximum length of directory names')
+    parser.add_argument('--min-filename-length',
+                        dest='min_filename_length',
+                        type=int,
+                        default=10,
+                        help='minimum length of file names')
+    parser.add_argument('--max-filename-length',
+                        dest='max_filename_length',
+                        type=int,
+                        default=10,
+                        help='maximum length of file names')
+
+    args = parser.parse_args()
+    name_chars = list(range(48, 57)) + list(range(65, 90)) + list(range(97, 122))
+
+    if os.path.exists(args.outdir):
+        shutil.rmtree(args.outdir)
+
+    os.mkdir(args.outdir)
+    create_random_subdirs(args.outdir, args.num_subdirs, name_chars, args.min_dirname_length, args.max_dirname_length, args.num_levels)
+    create_random_files(args.outdir, args.files_per_dir, name_chars, args.min_filename_length, args.max_filename_length, args.min_bytes_per_file, args.max_bytes_per_file, args.num_levels)
+
+
+if __name__ == '__main__':
+    main()

--- a/rndtree.sh
+++ b/rndtree.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+# http://stackoverflow.com/questions/13400312/linux-create-random-directory-file-hierarchy
+# Decimal ASCII codes (see man ascii); added space
+AARR=( 32 {48..57} {65..90} {97..122} )
+# Array count
+aarrcount=${#AARR[@]}
+
+if [ "$1" == "" ] ; then
+  OUTDIR="./rndpath" ;
+else
+  OUTDIR="$1" ;
+fi
+
+if [ "$2" != "" ] ; then
+  ASCIIONLY="$2" ;
+else
+  ASCIIONLY=1 ;
+fi
+
+if [ "$3" != "" ] ; then
+  DIRDEPTH="$3" ;
+else
+  DIRDEPTH=3 ;
+fi
+
+if [ "$4" != "" ] ; then
+  MAXFIRSTLEVELDIRS="$4" ;
+else
+  MAXFIRSTLEVELDIRS=2 ;
+fi
+
+if [ "$5" != "" ] ; then
+  MAXDIRCHILDREN="$5" ;
+else
+  MAXDIRCHILDREN=4 ;
+fi
+
+if [ "$6" != "" ] ; then
+  MAXDIRNAMELEN="$6" ;
+else
+  MAXDIRNAMELEN=12 ;
+fi
+
+if [ "$7" != "" ] ; then
+  MAXFILECHILDREN="$7" ;
+else
+  MAXFILECHILDREN=4 ;
+fi
+
+if [ "$8" != "" ] ; then
+  MAXFILENAMELEN="$8" ;
+else
+  MAXFILENAMELEN=20 ;
+fi
+
+if [ "$9" != "" ] ; then
+  MAXFILESIZE="$9" ;
+else
+  MAXFILESIZE=20000 ;
+fi
+
+MINDIRNAMELEN=1
+MINFILENAMELEN=1
+MINDIRCHILDREN=1
+MINFILECHILDREN=0
+MINFILESIZE=1000
+FILEEXT=".bin"
+VERBOSE=0 #1
+
+get_rand_dirname() {
+  if [ "$ASCIIONLY" == "1" ]; then
+    for ((i=0; i<$((MINDIRNAMELEN+RANDOM%MAXDIRNAMELEN)); i++)) {
+      printf \\$(printf '%03o' ${AARR[RANDOM%aarrcount]});
+    }
+  else
+    cat /dev/urandom | tr -dc '[ -~]' | tr -d '[$></~:`\\]' | head -c$((MINDIRNAMELEN + RANDOM % MAXDIRNAMELEN)) | sed 's/\(["]\)/\\\1/g'
+  fi
+  #echo -e " " # debug last dirname space
+}
+
+get_rand_filename() {
+  if [ "$ASCIIONLY" == "1" ]; then
+    for ((i=0; i<$((MINFILENAMELEN+RANDOM%MAXFILENAMELEN)); i++)) {
+      printf \\$(printf '%03o' ${AARR[RANDOM%aarrcount]});
+    }
+  else
+    # no need to escape double quotes for filename
+    cat /dev/urandom | tr -dc '[ -~]' | tr -d '[$></~:`\\]' | head -c$((MINFILENAMELEN + RANDOM % MAXFILENAMELEN)) #| sed 's/\(["]\)/\\\1/g'
+  fi
+  printf "%s" $FILEEXT
+}
+
+
+echo "Warning: will create random tree at: $OUTDIR"
+[ "$VERBOSE" == "1" ] && echo "  MAXFIRSTLEVELDIRS $MAXFIRSTLEVELDIRS ASCIIONLY $ASCIIONLY DIRDEPTH $DIRDEPTH MAXDIRCHILDREN $MAXDIRCHILDREN MAXDIRNAMELEN $MAXDIRNAMELEN MAXFILECHILDREN $MAXFILECHILDREN MAXFILENAMELEN $MAXFILENAMELEN MAXFILESIZE $MAXFILESIZE"
+
+read -p "Proceed (y/n)? " READANS
+if [ "$READANS" != "y" ]; then
+  exit
+fi
+
+if [ -d "$OUTDIR" ]; then
+  echo "Removing old outdir $OUTDIR"
+  rm -rf "$OUTDIR"
+fi
+
+mkdir "$OUTDIR"
+
+if [ $MAXFIRSTLEVELDIRS -gt 0 ]; then
+  NUMFIRSTLEVELDIRS=$((1+RANDOM%MAXFIRSTLEVELDIRS))
+else
+  NUMFIRSTLEVELDIRS=0
+fi
+
+
+
+# create directories
+for (( ifl=0;ifl<$((NUMFIRSTLEVELDIRS));ifl++ )) {
+  FLDIR="$(get_rand_dirname)"
+  FLCHILDREN="";
+  for (( ird=0;ird<$((DIRDEPTH-1));ird++ )) {
+    DIRCHILDREN=""; MOREDC=0;
+    for ((idc=0; idc<$((MINDIRCHILDREN+RANDOM%MAXDIRCHILDREN)); idc++)) {
+      CDIR="$(get_rand_dirname)" ;
+      # make sure comma is last, so brace expansion works even for 1 element? that can mess with expansion math, though
+      if [ "$DIRCHILDREN" == "" ]; then DIRCHILDREN="\"$CDIR\"" ;
+      else DIRCHILDREN="$DIRCHILDREN,\"$CDIR\"" ; MOREDC=1 ; fi
+    }
+    if [ "$MOREDC" == "1" ] ; then
+      if [ "$FLCHILDREN" == "" ]; then FLCHILDREN="{$DIRCHILDREN}" ;
+      else FLCHILDREN="$FLCHILDREN/{$DIRCHILDREN}" ; fi
+    else
+      if [ "$FLCHILDREN" == "" ]; then FLCHILDREN="$DIRCHILDREN" ;
+      else FLCHILDREN="$FLCHILDREN/$DIRCHILDREN" ; fi
+    fi
+  }
+  DIRCMD="mkdir -p $OUTDIR/\"$FLDIR\"/$FLCHILDREN"
+  eval "$DIRCMD"
+  echo "$DIRCMD"
+}
+
+# now loop through all directories, create random files inside
+# note printf '%q' escapes to preserve spaces; also here
+# escape, and don't wrap path parts in double quotes (e.g. | sed 's_/_"/"_g');
+# note then we STILL have to eval to use it!
+# but now ls "$D" works, so noneed for QD
+# unfortunately backslashes can make '%q' barf - prevent them
+find "$OUTDIR" -type d | while IFS= read D ; do
+  QD="$(printf '%q' "$(echo "$D")" )" ;
+  [ "$VERBOSE" == "1" ] && echo "$D"; #echo "$QD"; ls -la "$D"; #eval "ls -la $QD";
+  for ((ifc=0; ifc<$((MINFILECHILDREN+RANDOM%MAXFILECHILDREN)); ifc++)) {
+    CFILE="$(get_rand_filename)" ;
+    echo -n '> '
+    [ "$VERBOSE" == "1" ] && echo "$D"/"$CFILE"
+    cat /dev/urandom \
+    | head -c$((MINFILESIZE + RANDOM % MAXFILESIZE)) \
+    > "$D"/"$CFILE"
+  }
+done
+
+echo
+tree -a --dirsfirst -s "$OUTDIR"
+echo "total bytes: $(du -s $(echo "$OUTDIR"))"
+


### PR DESCRIPTION
Fixes DD-1066

# Description of changes
* Added a shell script from Stackoverflow: https://stackoverflow.com/questions/13400312/linux-create-random-directory-file-hierarchy. I found it usefull, but a bit hard to use; you have to read the script to understand the command line. Also, it is harder to generate an exact number of files. The script is called `rndtree.sh` and can be useful for cases where you need a great variety of datasets (big, small, many, few files, etc).
* Created a similar script that lets you generate random datasets with a more regular output. Easier to use for cases where you want to load-test Dataverse (or some other system): `generate-random-files.py`. See command line help for the options. Currently it will generate the same number of files in all the deepest directories. So for example, if you create a tree with 2 levels and 3 subdirs per level, with 25 files in each dir, you will end up with 3^2 * 25 files = 225 files.


# Notify
@DANS-KNAW/dataversedans
